### PR TITLE
Add build/publish workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: deploy
+
+on:
+  schedule:
+    # - cron: '30 5 1 * *'  # the first day of every month at 5:30 UTC
+    - cron: '30 5 * * *'  # every day at 5:30 UTC
+
+jobs:
+  create_ics:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out the repository
+      uses: actions/checkout@v3
+    
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v3
+      with:
+        python-version: 3.11.11
+        
+    - name: Install dependencies
+      run: |
+        pip install -r requirements.txt
+
+    - name: Build ics files
+      run: |
+        python pdf_2_ics.py
+      
+    - name: Publish files
+      uses: actions/upload-artifact@v4
+      with:
+        name: calendars
+        path: *.ics

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,4 +29,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: calendars
-        path: *.ics
+        path: ./*.ics


### PR DESCRIPTION
This should run ics generation and then publish the resulting ics files with actions/upload-artifact. I've set it up for now to run every day, to make sure it's working as expected. Later we can back off to once a month.