### PR TITLE
replace encrypted token secret with Google Workload Identity Federation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   create_ics:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # required for Workload Identity Federation
+      contents: read
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
@@ -39,12 +42,11 @@ jobs:
         name: old_links
         path: ./old_links.json
 
-    - name: Decrypt large secret
-      run: |
-        ./decrypt_secret.sh
-        python test_decrypt.py
-      env:
-        LARGE_SECRET_PASSPHRASE: ${{ secrets.LARGE_SECRET_PASSPHRASE }}
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+        service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
     - name: Post new menus to calendars
       run: |

--- a/gcal.py
+++ b/gcal.py
@@ -22,6 +22,7 @@ import pytz
 
 from ics import Calendar
 
+import google.auth
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
@@ -48,6 +49,11 @@ def authenticate():
     Raises:
         google.auth.exceptions.GoogleAuthError: If there is an error during the authentication process.
     """
+    # In CI, use Application Default Credentials set by google-github-actions/auth.
+    if os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"):
+        creds, _ = google.auth.default(scopes=SCOPES)
+        return creds
+
     creds = None
     # The file token.json stores the user's access and refresh tokens, and is
     # created automatically when authorization flow completes


### PR DESCRIPTION
Removes the GPG-decrypted token.json approach (which expired) in favour of google-github-actions/auth with Workload Identity Federation. In CI the script now picks up Application Default Credentials; locally the existing OAuth flow is unchanged.